### PR TITLE
Add conversion for special characters e.g. for HPSU 

### DIFF
--- a/main.js
+++ b/main.js
@@ -2691,13 +2691,21 @@ function getUnit(name) {
 function convertNameIob(ff, id) {
     let fn = ff + '[convertNameIob] ';
     let idFHEM = id.replace(/[-#:]/g, '_');
-    if (id !== idFHEM)
-        logDebug(fn, id, 'convertNameIob: ' + id + ' --> ' + idFHEM, 'D');
+    // Conversion back Iob->FHEM (required?)
+    idFHEM = idFHEM.replace(/{/g, '[');
+    idFHEM = idFHEM.replace(/}/g, ']');
+    idFHEM = idFHEM.replace(/~/g, '\.');
+    logDebug(fn, id, 'convertNameIob: ' + id + ' --> ' + idFHEM, 'D');
     return idFHEM;
 }
 function convertNameFHEM(ff, name) {
     let fn = ff + '[convertNameFHEM] ';
-    let id = name.replace(/\./g, '_');
+    // old: let id = name.replace(/\./g, '_');
+    // Conversion - e.g. for FHEM HPSU https://forum.fhem.de/index.php/topic,106503.0.htm HPSUVal.Betriebsart_[mode_01] ==> HPSUVal~Betriebsart_{mode_01}
+    let id = name.replace(/\./g, '~');
+    id = id.replace(/\[/g, '{'); 
+    id = id.replace(/\]/g, '}');
+    id = id.replace(/-#:/g, '_');
     if (name !== id)
         logDebug(fn, name, 'convertNameFHEM: ' + name + ' --> ' + id, 'D');
     return id;

--- a/main.js
+++ b/main.js
@@ -2695,7 +2695,8 @@ function convertNameIob(ff, id) {
     idFHEM = idFHEM.replace(/{/g, '[');
     idFHEM = idFHEM.replace(/}/g, ']');
     idFHEM = idFHEM.replace(/~/g, '\.');
-    logDebug(fn, id, 'convertNameIob: ' + id + ' --> ' + idFHEM, 'D');
+    if (id !== idFHEM)
+        logDebug(fn, id, 'convertNameIob: ' + id + ' --> ' + idFHEM, 'D');
     return idFHEM;
 }
 function convertNameFHEM(ff, name) {


### PR DESCRIPTION
HPSU module of FHEM uses attribute names with special characters (HPSUVal.Betriebsart_[mode_01])
https://forum.fhem.de/index.php/topic,106503.0.htm

Special characters in names result in hundrets of warnings in ioBroker log:
Used invalid characters: fhem.0.myHPSU.HPSUVal_Soll_T_Warmwasser_3_[t_dhw_setpoint3] changed to fhem.0.myHPSU.HPSUVal_Soll_T_Warmwasser_3__t_dhw_setpoint3_

Sending values back from Iob to FHEM does not work
see: https://forum.iobroker.net/post/506919

Therefore I added some additional character replacements:
=> HPSUVal.Betriebsart_[mode_01] ==> HPSUVal~Betriebsart_{mode_01}
Now everything works fine.

Is this compatible with other scenarios?
Should I restrict this conversion only to HPSU attributes?
Thank you for reviewing!
